### PR TITLE
Fix bug with improper cluster threshold set for variable threshold situations

### DIFF
--- a/src/extract.c
+++ b/src/extract.c
@@ -58,6 +58,7 @@ int sortit(infostruct *info, objliststruct *objlist, int minarea,
 	   deblendctx *deblendctx);
 void plistinit(int hasconv, int hasvar);
 void clean(objliststruct *objlist, double clean_param, int *survives);
+PIXTYPE get_mean_thresh(infostruct *info, pliststruct *pixel);
 int convert_to_catalog(objliststruct *objlist, const int *survives,
                        sep_catalog *cat, int w, int include_pixels);
 
@@ -626,7 +627,10 @@ int sep_extract(const sep_image *image, float thresh, int thresh_type,
 			  if ((int)info[co].pixnb >= minarea)
 			    {
 			      /* update threshold before object is processed */
-			      objlist.thresh = thresh;
+			      if (PLISTEXIST(thresh))
+			    objlist.thresh = get_mean_thresh(&info[co], objlist.plist);
+			      else
+			    objlist.thresh = thresh;
 
 			      status = sortit(&info[co], &objlist, minarea,
 					      finalobjlist,
@@ -993,6 +997,25 @@ void clean(objliststruct *objlist, double clean_param, int *survives)
     } /* outer loop of objlist (obj1) */
 }
 
+/************************** get_mean_thresh **********************************/
+/*
+Compute an average threshold from all pixels in the cluster
+*/
+PIXTYPE get_mean_thresh(infostruct *info, pliststruct *pixel)
+{
+  pliststruct   *pixt;
+  int           pix_accum=0;
+  PIXTYPE       thresh_accum=0;
+
+  for (pixt=pixel+info->firstpix; pixt>=pixel;
+       pixt=pixel+PLIST(pixt,nextpix))
+    {
+      thresh_accum += PLISTPIX(pixt,thresh);
+      pix_accum++;
+    }
+
+  return thresh_accum / pix_accum;
+}
 
 /*****************************************************************************/
 /* sep_catalog manipulations */


### PR DESCRIPTION
If a noise matrix and relative threshold are used and the bottom right corner of a cluster is masked, then the objlist threshold will be corrupted and values like tnpix are improperly extracted. More generally, tnpix values are not currently accurate given it is computed against a non-detection pixel's threshold.

More info:
When a variable threshold is at play, the objlist threshold is set to the first non-detection pixel value that "closes off" the cluster. This is typically the pixel just below and to the right of the actually detected star pixels. If that pixel is masked out, then the objlist threshold is set to the relative threshold times 1e30 (the masked pixel sigma value). Hence when tnpix is computed later, nothing is above that threshold. This patch will fix that by computing the cluster threshold from the average of each pixel's threshold in the cluster.