### PR TITLE
Update ``bench.py``

### DIFF
--- a/bench.py
+++ b/bench.py
@@ -87,7 +87,7 @@ for ntile in [4]:
     line = "| {0:4d}^2 image background |".format(data.shape[0])
 
     t0 = time.time()
-    for _ in xrange(0, nloop):
+    for _ in range(0, nloop):
         bkg = sep.Background(data)
     t1 = time.time()
     t_sep = (t1-t0) * 1.e3 / nloop
@@ -95,7 +95,7 @@ for ntile in [4]:
 
     if HAVE_PHOTUTILS:
         t0 = time.time()
-        for _ in xrange(0, nloop):
+        for _ in range(0, nloop):
             try:
                 bkg = photutils.Background(data, (64, 64))  # estimate background
             except AttributeError:
@@ -135,7 +135,7 @@ for r in r_list:
         line = "| circles  r={0:2d}  {1:8s} |".format(int(r), label)
 
         t0 = time.time()
-        for _ in xrange(0, nloop):
+        for _ in range(0, nloop):
             flux, fluxerr, flag = sep.sum_circle(data, x, y, r, subpix=subpix)
         t1 = time.time()
         t_sep = (t1-t0) * 1.e6 / naper / nloop
@@ -144,7 +144,7 @@ for r in r_list:
         if HAVE_PHOTUTILS:
             apertures = photutils.CircularAperture((x, y), r)
             t0 = time.time()
-            for _ in xrange(0, nloop):
+            for _ in range(0, nloop):
                 res = photutils.aperture_photometry(
                     data, apertures, method=method, subpixels=subpix)
             t1 = time.time()
@@ -165,7 +165,7 @@ for r in r_list:
         line = "| ellipses r={0:2d}  {1:8s} |".format(int(r), label)
 
         t0 = time.time()
-        for _ in xrange(0, nloop):
+        for _ in range(0, nloop):
             flux, fluxerr, flag = sep.sum_ellipse(data, x, y, a, b, theta, r,
                                                 subpix=subpix)
         t1 = time.time()
@@ -175,7 +175,7 @@ for r in r_list:
         if HAVE_PHOTUTILS:
             apertures = photutils.EllipticalAperture((x, y), a*r, b*r, theta)
             t0 = time.time()
-            for _ in xrange(0, nloop):
+            for _ in range(0, nloop):
                 res = photutils.aperture_photometry(
                     data, apertures, method=method, subpixels=subpix)
             t1 = time.time()

--- a/bench.py
+++ b/bench.py
@@ -99,7 +99,7 @@ for ntile in [4]:
             try:
                 bkg = photutils.Background(data, (64, 64))  # estimate background
             except AttributeError:
-                bkg = photutils.Background2D(data, (64, 64))  # estimate background
+                bkg = photutils.background.Background2D(data, (64, 64))  # estimate background
         t1 = time.time()
         t_pu = (t1-t0) * 1.e3 / nloop
         line += "      {0:7.2f} ms | {1:6.2f} |".format(t_pu, t_pu/t_sep)
@@ -142,10 +142,10 @@ for r in r_list:
         line += " {0:7.2f} us/aper |".format(t_sep)
 
         if HAVE_PHOTUTILS:
-            apertures = photutils.CircularAperture((x, y), r)
+            apertures = photutils.aperture.CircularAperture(np.array((x, y)).T, r)
             t0 = time.time()
             for _ in range(0, nloop):
-                res = photutils.aperture_photometry(
+                res = photutils.aperture.aperture_photometry(
                     data, apertures, method=method, subpixels=subpix)
             t1 = time.time()
             t_pu = (t1-t0) * 1.e6 / naper / nloop
@@ -173,10 +173,10 @@ for r in r_list:
         line += " {0:7.2f} us/aper |".format(t_sep)
 
         if HAVE_PHOTUTILS:
-            apertures = photutils.EllipticalAperture((x, y), a*r, b*r, theta)
+            apertures = photutils.aperture.EllipticalAperture(np.array((x, y)).T, a*r, b*r, theta)
             t0 = time.time()
             for _ in range(0, nloop):
-                res = photutils.aperture_photometry(
+                res = photutils.aperture.aperture_photometry(
                     data, apertures, method=method, subpixels=subpix)
             t1 = time.time()
             t_pu = (t1-t0) * 1.e6 / naper / nloop


### PR DESCRIPTION
``xrange`` became ``range`` in python 3 (``range`` still works in python 2). 

Also, photutils deprecated ``photutils.Background2D`` etc, which caused hundreds of warning lines when running ``bench.py``.

