### PR TITLE
Make it possible to use sep as a CMake subdirectory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 2.6)
 
 project(sep C)
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
 include(GNUInstallDirs)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,28 +2,26 @@ cmake_minimum_required(VERSION 2.6)
 
 project(sep C)
 
-LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake_modules/")
+LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/")
 include(GNUInstallDirs)
 
 set(SOURCES
-   ${CMAKE_SOURCE_DIR}/src/analyse.c
-   ${CMAKE_SOURCE_DIR}/src/convolve.c
-   ${CMAKE_SOURCE_DIR}/src/deblend.c
-   ${CMAKE_SOURCE_DIR}/src/extract.c
-   ${CMAKE_SOURCE_DIR}/src/lutz.c
-   ${CMAKE_SOURCE_DIR}/src/aperture.c
-   ${CMAKE_SOURCE_DIR}/src/background.c
-   ${CMAKE_SOURCE_DIR}/src/util.c
+   ${CMAKE_CURRENT_SOURCE_DIR}/src/analyse.c
+   ${CMAKE_CURRENT_SOURCE_DIR}/src/convolve.c
+   ${CMAKE_CURRENT_SOURCE_DIR}/src/deblend.c
+   ${CMAKE_CURRENT_SOURCE_DIR}/src/extract.c
+   ${CMAKE_CURRENT_SOURCE_DIR}/src/lutz.c
+   ${CMAKE_CURRENT_SOURCE_DIR}/src/aperture.c
+   ${CMAKE_CURRENT_SOURCE_DIR}/src/background.c
+   ${CMAKE_CURRENT_SOURCE_DIR}/src/util.c
    )
-
-include_directories(${CMAKE_INCLUDE_PATH} ${CMAKE_SOURCE_DIR}/src ${CFITSIO_INCLUDE_DIR})
-
-link_directories(${CMAKE_LIBRARY_PATH} ${CMAKE_SOURCE_DIR}/src)
 
 add_library(sep SHARED ${SOURCES})
 set_target_properties(sep PROPERTIES OUTPUT_NAME sep)
 set_target_properties(sep PROPERTIES VERSION 0.6.0 SOVERSION 0)
 set_target_properties(sep PROPERTIES C_VISIBILITY_PRESET hidden)
+target_include_directories(sep PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src ${CFITSIO_INCLUDE_DIR})
+target_link_directories(sep PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
 if (MSVC)
    add_definitions(-D_USE_MATH_DEFINES)
@@ -33,4 +31,4 @@ else ()
 endif()
 
 install(TARGETS sep LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
-install(FILES ${CMAKE_SOURCE_DIR}/src/sep.h DESTINATION include)
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/src/sep.h DESTINATION include)


### PR DESCRIPTION
In this PR I add support for convenient use as a submodule. Now this CMake code produces correct configuration:

```
add_subdirectory(<path-to-subdirectory>/sep)
target_link_libraries(<your-target> PUBLIC <other-libraries> sep)
```

This PR contains following changes:

- Use CMAKE_CURRENT_SOURCE_DIR for correct path resolution
- Use target_include_directories and target_link_directories for correct dependency resolution
- Export compile commands for linters
