### PR TITLE
Maskthresh

### DIFF
--- a/.github/workflows/build-wheels-upload-pypi.yml
+++ b/.github/workflows/build-wheels-upload-pypi.yml
@@ -29,7 +29,7 @@ jobs:
     # First the source distribution is done on ubuntu. This is not related
     # to any operating system, so we could do it on the default os.
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - name: checkout
@@ -84,19 +84,10 @@ jobs:
       max-parallel: 4
       matrix:
         python-version: ["3.12"]
-        os: [windows-latest, macos-latest, ubuntu-latest]
-        include:
-          - os: ubuntu-20.04
-            cibw_archs: "aarch64"
+        os: [windows-latest, macos-latest, ubuntu-24.04, ubuntu-24.04-arm]
 
     steps:
       - uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        if: runner.os == 'Linux'
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm64
 
       - name: checkout
         uses: actions/checkout@v4
@@ -113,18 +104,6 @@ jobs:
         run: python -m pip install cibuildwheel
 
       - name: Build wheels
-        if: matrix.cibw_archs == 'aarch64'
-        run: python -m cibuildwheel --output-dir wheelhouse
-        env:
-          CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-* cp313-*"
-          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
-          CIBW_MANYLINUX_I686_IMAGE: manylinux2014
-          CIBW_BUILD_VERBOSITY: 1
-          CIBW_SKIP: '*-musllinux_*'
-          CIBW_ARCHS_LINUX: "aarch64"
-
-      - name: Build wheels
-        if: matrix.cibw_archs != 'aarch64'
         run: python -m cibuildwheel --output-dir wheelhouse
         env:
           CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-* cp313-*"

--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 SEP
 ===
 
-Python and C library for Source Extraction and Photometry, originally
-developed at [kbarbary/sep](https://github.com/kbarbary/sep) and later
-maintained at [PJ-Watson/sep-pjw](https://github.com/PJ-Watson/sep-pjw).
+Python and C library for Source Extraction and Photometry.
 
 [![PyPI](https://img.shields.io/pypi/v/sep?label=PyPI)](https://pypi.python.org/pypi/sep)
 [![PyPI - Downloads](https://img.shields.io/pypi/dm/sep?label=PyPI%20Downloads)
@@ -65,7 +63,7 @@ instructions.
 Python
 ------
 
-**Documentation:** http://sep-pjw.readthedocs.io
+**Documentation:** http://sep.readthedocs.io
 
 **Requirements:**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools>=61.0",
+    "setuptools>=61.0, <72.2.0",
     "wheel",
     "numpy>=2.0.0rc2",
     "Cython",

--- a/test.py
+++ b/test.py
@@ -552,21 +552,23 @@ def test_extract_with_maskthresh():
     # mask half the image
     ylim = data.shape[0] // 2
     mask = np.zeros(data.shape, dtype=float)
-    mask[ylim:, :] = 1.
+    mask[ylim:, :] = 1.0
 
-    objects_unmasked = sep.extract(data, 1.5 * bkg.globalrms)
-    objects_unmasked_w_thresh = sep.extract(data, 1.5 * bkg.globalrms, maskthresh=1.0)
+    objects_unmasked = sep.extract(data, 1.5 * bkg.globalrms, deblend_cont=1.0)
+    objects_unmasked_w_thresh = sep.extract(
+        data, 1.5 * bkg.globalrms, maskthresh=1.0, deblend_cont=1.0
+    )
 
     # Check that changing the mask threshold does not change anything,
     # if no mask is provided
     assert_allclose_structured(objects_unmasked, objects_unmasked_w_thresh)
 
-    objects_masked = sep.extract(data, 1.5 * bkg.globalrms, mask=mask)
+    objects_masked = sep.extract(data, 1.5 * bkg.globalrms, mask=mask, deblend_cont=1.0)
     objects_masked_w_hthresh = sep.extract(
-        data, 1.5 * bkg.globalrms, mask=mask, maskthresh=1.0
+        data, 1.5 * bkg.globalrms, mask=mask, maskthresh=1.0, deblend_cont=1.0
     )
     objects_masked_w_lthresh = sep.extract(
-        data, 1.5 * bkg.globalrms, mask=mask, maskthresh=0.5
+        data, 1.5 * bkg.globalrms, mask=mask, maskthresh=0.5, deblend_cont=1.0
     )
 
     # Applying a mask should return a different number of objects

--- a/test.py
+++ b/test.py
@@ -551,8 +551,8 @@ def test_extract_with_maskthresh():
 
     # mask half the image
     ylim = data.shape[0] // 2
-    mask = np.zeros(data.shape, dtype=np.bool_)
-    mask[ylim:, :] = True
+    mask = np.zeros(data.shape, dtype=float)
+    mask[ylim:, :] = 1.
 
     objects_unmasked = sep.extract(data, 1.5 * bkg.globalrms)
     objects_unmasked_w_thresh = sep.extract(data, 1.5 * bkg.globalrms, maskthresh=1.0)


### PR DESCRIPTION
Fix `maskthresh` not being applied, update docs to clarify, and add relevant tests. Closes #133 , #137, and #149. 

_For future:_ Not immediately clear why deblending fails on windows, but passes on other platforms.